### PR TITLE
Fix collection to array conversion

### DIFF
--- a/src/no/runsafe/framework/internal/extension/player/RunsafePlayer.java
+++ b/src/no/runsafe/framework/internal/extension/player/RunsafePlayer.java
@@ -19,7 +19,6 @@ import no.runsafe.framework.text.ChatColour;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.craftbukkit.v1_8_R3.entity.CraftPlayer;
 import org.joda.time.DateTime;
 
 import javax.annotation.Nonnull;
@@ -31,11 +30,6 @@ import java.util.Map;
 public class RunsafePlayer extends BukkitPlayer implements IPlayer
 {
 	public RunsafePlayer(OfflinePlayer toWrap)
-	{
-		super(toWrap);
-	}
-
-	public RunsafePlayer(CraftPlayer toWrap)
 	{
 		super(toWrap);
 	}

--- a/src/no/runsafe/framework/internal/wrapper/BukkitServer.java
+++ b/src/no/runsafe/framework/internal/wrapper/BukkitServer.java
@@ -137,7 +137,7 @@ public abstract class BukkitServer implements IWrapper<Server>
 
 	public List<IPlayer> getOnlinePlayers()
 	{
-		return ObjectWrapper.convert((CraftPlayer[]) server.getOnlinePlayers().toArray());
+		return ObjectWrapper.convert(server.getOnlinePlayers().toArray(new CraftPlayer[server.getOnlinePlayers().size()]));
 	}
 
 	public List<IPlayer> getOperators()

--- a/src/no/runsafe/framework/internal/wrapper/BukkitServer.java
+++ b/src/no/runsafe/framework/internal/wrapper/BukkitServer.java
@@ -9,8 +9,6 @@ import no.runsafe.framework.internal.extension.player.RunsafePlayer;
 import no.runsafe.framework.text.ChatColour;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.Server;
-import org.bukkit.craftbukkit.v1_8_R3.entity.CraftPlayer;
-import org.bukkit.entity.Player;
 import org.bukkit.map.MapView;
 
 import javax.annotation.Nullable;
@@ -137,7 +135,7 @@ public abstract class BukkitServer implements IWrapper<Server>
 
 	public List<IPlayer> getOnlinePlayers()
 	{
-		return ObjectWrapper.convert(server.getOnlinePlayers().toArray(new CraftPlayer[server.getOnlinePlayers().size()]));
+		return ObjectWrapper.convert(server.getOnlinePlayers().toArray(new OfflinePlayer[server.getOnlinePlayers().size()]));
 	}
 
 	public List<IPlayer> getOperators()

--- a/src/no/runsafe/framework/internal/wrapper/player/BukkitPlayer.java
+++ b/src/no/runsafe/framework/internal/wrapper/player/BukkitPlayer.java
@@ -14,7 +14,6 @@ import no.runsafe.framework.minecraft.item.meta.RunsafeMeta;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.craftbukkit.v1_8_R3.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
 import javax.annotation.Nullable;
@@ -23,13 +22,6 @@ import java.net.InetSocketAddress;
 public class BukkitPlayer extends RunsafeLivingEntity implements IInventoryHolder, IAnimalTamer
 {
 	protected BukkitPlayer(OfflinePlayer toWrap)
-	{
-		super(toWrap instanceof Player ? (Player) toWrap : null);
-		player = toWrap instanceof Player ? (Player) toWrap : null;
-		basePlayer = toWrap;
-	}
-
-	protected BukkitPlayer(CraftPlayer toWrap)
 	{
 		super(toWrap instanceof Player ? (Player) toWrap : null);
 		player = toWrap instanceof Player ? (Player) toWrap : null;


### PR DESCRIPTION
.toArray() on a collection just returns a Ljava.lang.object rather than a CraftPlayer, which can't be cast to a CraftPlayer.  This pull request should fix that.