### PR TITLE
Fix issues with usernames and UUIDs

### DIFF
--- a/src/no/runsafe/framework/api/hook/IPlayerExtensions.java
+++ b/src/no/runsafe/framework/api/hook/IPlayerExtensions.java
@@ -33,6 +33,7 @@ public interface IPlayerExtensions
 	List<String> find(String playerName);
 	@Nullable
 	UUID getUniqueId(String playerName);
+	String getPlayerName(UUID playerId);
 	void addPermission(IPlayer player, String permission, String world);
 	void addPermission(IPlayer player, String permission);
 	void removePermission(IPlayer player, String permission, String world);

--- a/src/no/runsafe/framework/api/hook/IPlayerLookupService.java
+++ b/src/no/runsafe/framework/api/hook/IPlayerLookupService.java
@@ -13,7 +13,6 @@ public interface IPlayerLookupService extends IFrameworkHook
 
 	/**
 	 * Looks up the Unique Id of the player who logged the most recently with a specified username.
-	 * Intended to help with converting player usernames to UUIDs.
 	 *
 	 * @param playerName Exact name of the player to lookup.
 	 * @return the UUID of the last player to loged in.

--- a/src/no/runsafe/framework/api/hook/IPlayerLookupService.java
+++ b/src/no/runsafe/framework/api/hook/IPlayerLookupService.java
@@ -20,4 +20,15 @@ public interface IPlayerLookupService extends IFrameworkHook
 	 */
 	@Nullable
 	UUID findPlayerUniqueId(String playerName);
+
+	/**
+	 * Gets the most recent username a player has logged in with.
+	 *
+	 * @param playerId The player's identifying number.
+	 * @return The latest username a player has logged in with.
+	 *         Might not be the player's current username.
+	 *         Null if the player has never logged into the server.
+	 */
+	@Nullable
+	String getLatestUsername(UUID playerId);
 }

--- a/src/no/runsafe/framework/api/server/IPlayerManager.java
+++ b/src/no/runsafe/framework/api/server/IPlayerManager.java
@@ -22,7 +22,4 @@ public interface IPlayerManager
 	Set<String> getIpBans();
 
 	void unbanIP(String ip);
-
-	@Nullable
-	UUID getUniqueId(String playerName);
 }

--- a/src/no/runsafe/framework/internal/extension/RunsafeServer.java
+++ b/src/no/runsafe/framework/internal/extension/RunsafeServer.java
@@ -287,7 +287,6 @@ public class RunsafeServer extends BukkitServer implements IServer
 	 * @return the UUID of the last player to loged in.
 	 *         Null if the player can't be found.
 	 */
-	@Override
 	@Nullable
 	public UUID getUniqueId(String playerName)
 	{

--- a/src/no/runsafe/framework/internal/extension/RunsafeServer.java
+++ b/src/no/runsafe/framework/internal/extension/RunsafeServer.java
@@ -281,7 +281,6 @@ public class RunsafeServer extends BukkitServer implements IServer
 
 	/**
 	 * Provides the Unique Id of the player who logged the most recently with a specified username.
-	 * Intended to help with converting player usernames to UUIDs.
 	 *
 	 * @param playerName Exact name of the player to lookup.
 	 * @return the UUID of the last player to loged in.

--- a/src/no/runsafe/framework/internal/extension/RunsafeServer.java
+++ b/src/no/runsafe/framework/internal/extension/RunsafeServer.java
@@ -141,6 +141,15 @@ public class RunsafeServer extends BukkitServer implements IServer
 		return new RunsafePlayer(player);
 	}
 
+	@Override
+	@Nullable
+	public IPlayer getOfflinePlayerExact(String playerName)
+	{
+		if (playerName == null || playerName.isEmpty())
+			return null;
+		return new RunsafePlayer(server.getOfflinePlayer(playerName));
+	}
+
 	@Nonnull
 	public static List<String> findPlayer(String playerName)
 	{

--- a/src/no/runsafe/framework/internal/extension/RunsafeServer.java
+++ b/src/no/runsafe/framework/internal/extension/RunsafeServer.java
@@ -151,9 +151,9 @@ public class RunsafeServer extends BukkitServer implements IServer
 		UUID playerId = getUniqueId(playerName);
 
 		if (playerId == null)
-			return new RunsafePlayer(server.getOfflinePlayer(playerName));
+			return new RunsafePlayer(server.getOfflinePlayer(playerName), playerName);
 		else
-			return new RunsafePlayer(server.getOfflinePlayer(playerId));
+			return new RunsafePlayer(server.getOfflinePlayer(playerId), playerName);
 	}
 
 	@Nonnull

--- a/src/no/runsafe/framework/internal/extension/RunsafeServer.java
+++ b/src/no/runsafe/framework/internal/extension/RunsafeServer.java
@@ -52,7 +52,7 @@ public class RunsafeServer extends BukkitServer implements IServer
 			return null;
 
 		if (hits.size() == 1)
-			return new RunsafePlayer(server.getOfflinePlayer(hits.get(0)));
+			return getOfflinePlayerExact(playerName);
 
 		return new RunsafeAmbiguousPlayer(server.getOfflinePlayer(hits.get(0)), hits);
 	}
@@ -136,7 +136,7 @@ public class RunsafeServer extends BukkitServer implements IServer
 		if (player == null)
 		{
 			List<String> players = findPlayer(playerName);
-			return players.contains(playerName) ? new RunsafePlayer(server.getOfflinePlayer(playerName)) : null;
+			return players.contains(playerName) ? getOfflinePlayerExact(playerName) : null;
 		}
 		return new RunsafePlayer(player);
 	}
@@ -147,7 +147,13 @@ public class RunsafeServer extends BukkitServer implements IServer
 	{
 		if (playerName == null || playerName.isEmpty())
 			return null;
-		return new RunsafePlayer(server.getOfflinePlayer(playerName));
+
+		UUID playerId = getUniqueId(playerName);
+
+		if (playerId == null)
+			return new RunsafePlayer(server.getOfflinePlayer(playerName));
+		else
+			return new RunsafePlayer(server.getOfflinePlayer(playerId));
 	}
 
 	@Nonnull

--- a/src/no/runsafe/framework/internal/extension/player/RunsafePlayer.java
+++ b/src/no/runsafe/framework/internal/extension/player/RunsafePlayer.java
@@ -126,6 +126,7 @@ public class RunsafePlayer extends BukkitPlayer implements IPlayer
 			Location location = player.getLocation();
 			data.put("game.location", String.format("[%.2f,%.2f,%.2f@%s]", location.getX(), location.getY(), location.getZ(), location.getWorld().getName()));
 		}
+		data.put("game.uniqueId", getUniqueId().toString());
 		data.put("game.experience", String.format("%.1f", getXP()));
 		data.put("game.level", String.format("%d", getLevel()));
 		data.put("game.op", isOP() ? "true" : "false");

--- a/src/no/runsafe/framework/internal/extension/player/RunsafePlayer.java
+++ b/src/no/runsafe/framework/internal/extension/player/RunsafePlayer.java
@@ -34,6 +34,12 @@ public class RunsafePlayer extends BukkitPlayer implements IPlayer
 		super(toWrap);
 	}
 
+	public RunsafePlayer(OfflinePlayer toWrap, String playerName)
+	{
+		super(toWrap);
+		this.playerName = playerName;
+	}
+
 	@Override
 	public String getPrettyName()
 	{

--- a/src/no/runsafe/framework/internal/hooks/PlayerExtensions.java
+++ b/src/no/runsafe/framework/internal/hooks/PlayerExtensions.java
@@ -253,6 +253,19 @@ public final class PlayerExtensions implements IPlayerExtensions
 		return null;
 	}
 
+	@Override
+	@Nullable
+	public String getPlayerName(UUID playerId)
+	{
+		if (playerId == null)
+			return null;
+
+		for (IPlayerLookupService lookup : getHooks(IPlayerLookupService.class))
+			return lookup.getLatestUsername(playerId);
+
+		return null;
+	}
+
 	private static <T> List<T> getHooks(Class<T> type)
 	{
 		return HookEngine.getHooks(type);

--- a/src/no/runsafe/framework/internal/wrapper/BukkitServer.java
+++ b/src/no/runsafe/framework/internal/wrapper/BukkitServer.java
@@ -115,14 +115,6 @@ public abstract class BukkitServer implements IWrapper<Server>
 		return server.getName();
 	}
 
-	@Nullable
-	public IPlayer getOfflinePlayerExact(String playerName)
-	{
-		if (playerName == null || playerName.isEmpty())
-			return null;
-		return new RunsafePlayer(server.getOfflinePlayer(playerName));
-	}
-
 	public List<IPlayer> getOfflinePlayers()
 	{
 		return ObjectWrapper.convert(server.getOfflinePlayers());

--- a/src/no/runsafe/framework/internal/wrapper/player/BukkitPlayer.java
+++ b/src/no/runsafe/framework/internal/wrapper/player/BukkitPlayer.java
@@ -2,8 +2,10 @@ package no.runsafe.framework.internal.wrapper.player;
 
 import no.runsafe.framework.api.ILocation;
 import no.runsafe.framework.api.block.IBlock;
+import no.runsafe.framework.api.hook.IPlayerExtensions;
 import no.runsafe.framework.api.minecraft.IAnimalTamer;
 import no.runsafe.framework.api.minecraft.IInventoryHolder;
+import no.runsafe.framework.internal.InjectionPlugin;
 import no.runsafe.framework.internal.LegacyMaterial;
 import no.runsafe.framework.internal.wrapper.ObjectUnwrapper;
 import no.runsafe.framework.internal.wrapper.ObjectWrapper;
@@ -40,6 +42,10 @@ public class BukkitPlayer extends RunsafeLivingEntity implements IInventoryHolde
 			return null;
 
 		playerName = basePlayer.getName();
+		if (playerName != null)
+			return playerName;
+
+		playerName = InjectionPlugin.getGlobalComponent(IPlayerExtensions.class).getPlayerName(getUniqueId());
 		if (playerName != null)
 			return playerName;
 

--- a/src/no/runsafe/framework/internal/wrapper/player/BukkitPlayer.java
+++ b/src/no/runsafe/framework/internal/wrapper/player/BukkitPlayer.java
@@ -33,7 +33,18 @@ public class BukkitPlayer extends RunsafeLivingEntity implements IInventoryHolde
 	@Nullable
 	public String getName()
 	{
-		return basePlayer == null ? null : basePlayer.getName();
+		if (playerName != null)
+			return playerName;
+
+		if (nullName || basePlayer == null)
+			return null;
+
+		playerName = basePlayer.getName();
+		if (playerName != null)
+			return playerName;
+
+		nullName = true;
+		return null;
 	}
 
 	public void closeInventory()
@@ -311,6 +322,8 @@ public class BukkitPlayer extends RunsafeLivingEntity implements IInventoryHolde
 			player.resetTitle();
 	}
 
+	protected String playerName = null;
+	private boolean nullName = false;
 	@Nullable
 	protected final Player player;
 	protected final OfflinePlayer basePlayer;

--- a/src/no/runsafe/framework/minecraft/player/RunsafeFakePlayer.java
+++ b/src/no/runsafe/framework/minecraft/player/RunsafeFakePlayer.java
@@ -17,7 +17,7 @@ public class RunsafeFakePlayer extends RunsafePlayer implements IFakePlayer
 	public RunsafeFakePlayer(String playerName, String... groups)
 	{
 		super(null);
-		name = playerName;
+		this.playerName = playerName;
 		this.groups = ImmutableList.copyOf(groups);
 	}
 
@@ -25,12 +25,6 @@ public class RunsafeFakePlayer extends RunsafePlayer implements IFakePlayer
 	public boolean hasPermission(String permission)
 	{
 		return InjectionPlugin.getGlobalComponent(IPlayerExtensions.class).hasPermission(this, groups, permission);
-	}
-
-	@Override
-	public String getName()
-	{
-		return name;
 	}
 
 	@Override
@@ -109,7 +103,7 @@ public class RunsafeFakePlayer extends RunsafePlayer implements IFakePlayer
 			return false;
 
 		if(o instanceof RunsafeFakePlayer)
-			return this.name.equals(((RunsafeFakePlayer) o).getName());
+			return this.playerName.equals(((RunsafeFakePlayer) o).getName());
 
 		return false;
 	}
@@ -117,10 +111,9 @@ public class RunsafeFakePlayer extends RunsafePlayer implements IFakePlayer
 	@Override
 	public int hashCode()
 	{
-		return name.hashCode();
+		return playerName.hashCode();
 	}
 
-	private final String name;
 	private final ImmutableList<String> groups;
 	private boolean isOp;
 	private IWorld world;


### PR DESCRIPTION
- Allow whois command to display a player's UUID.  
- Optimize getting a player's username
- Prevent null usernames when getting players by their UUIDs.
- Prevent incorrect UUIDs when getting players by their usernames.