### PR TITLE
Add console UUID, deprecate uses of block IDs for futureproofing.

### DIFF
--- a/src/no/runsafe/framework/api/entity/ILivingEntity.java
+++ b/src/no/runsafe/framework/api/entity/ILivingEntity.java
@@ -25,9 +25,15 @@ public interface ILivingEntity extends IDamageable, IProjectileSource
 	double getEyeHeight();
 	double getEyeHeight(boolean ignoreSneaking);
 	ILocation getEyeLocation();
-	List<IBlock> getLineOfSight(HashSet<Material> transparent, int maxDistance);
-	IBlock getTargetBlock(HashSet<Material> transparent, int maxDistance);
-	List<IBlock> getLastTwoTargetBlocks(HashSet<Material> transparent, int maxDistance);
+	List<IBlock> getBlocksInLineOfSight(HashSet<Material> transparent, int maxDistance);
+	IBlock getTargetedBlock(HashSet<Material> transparent, int maxDistance);
+	List<IBlock> getLastTwoTargetedBlocks(HashSet<Material> transparent, int maxDistance);
+	@Deprecated
+	List<IBlock> getLineOfSight(HashSet<Byte> transparent, int maxDistance);
+	@Deprecated
+	IBlock getTargetBlock(HashSet<Byte> transparent, int maxDistance);
+	@Deprecated
+	List<IBlock> getLastTwoTargetBlocks(HashSet<Byte> transparent, int maxDistance);
 	int getRemainingAir();
 	void setRemainingAir(int remainingAirTicks);
 	int getMaximumAir();

--- a/src/no/runsafe/framework/api/entity/ILivingEntity.java
+++ b/src/no/runsafe/framework/api/entity/ILivingEntity.java
@@ -9,6 +9,7 @@ import no.runsafe.framework.minecraft.Sound;
 import no.runsafe.framework.minecraft.entity.ProjectileEntity;
 import no.runsafe.framework.minecraft.entity.RunsafeEntity;
 import no.runsafe.framework.minecraft.inventory.RunsafeEntityEquipment;
+import org.bukkit.Material;
 
 import javax.annotation.Nullable;
 import java.util.HashSet;
@@ -24,9 +25,9 @@ public interface ILivingEntity extends IDamageable, IProjectileSource
 	double getEyeHeight();
 	double getEyeHeight(boolean ignoreSneaking);
 	ILocation getEyeLocation();
-	List<IBlock> getLineOfSight(HashSet<Byte> transparent, int maxDistance);
-	IBlock getTargetBlock(HashSet<Byte> transparent, int maxDistance);
-	List<IBlock> getLastTwoTargetBlocks(HashSet<Byte> transparent, int maxDistance);
+	List<IBlock> getLineOfSight(HashSet<Material> transparent, int maxDistance);
+	IBlock getTargetBlock(HashSet<Material> transparent, int maxDistance);
+	List<IBlock> getLastTwoTargetBlocks(HashSet<Material> transparent, int maxDistance);
 	int getRemainingAir();
 	void setRemainingAir(int remainingAirTicks);
 	int getMaximumAir();

--- a/src/no/runsafe/framework/internal/LegacyMaterial.java
+++ b/src/no/runsafe/framework/internal/LegacyMaterial.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 @SuppressWarnings("MagicNumber")
+@Deprecated
 public final class LegacyMaterial
 {
 	public static Material getById(int id)

--- a/src/no/runsafe/framework/internal/wrapper/BukkitWorld.java
+++ b/src/no/runsafe/framework/internal/wrapper/BukkitWorld.java
@@ -48,11 +48,13 @@ public abstract class BukkitWorld extends BukkitMetadata
 		return ObjectWrapper.convert(world.getBlockAt(x, y, z));
 	}
 
+	@Deprecated
 	public int getBlockTypeIdAt(ILocation location)
 	{
 		return LegacyMaterial.getIdOf(world.getBlockAt((Location) ObjectUnwrapper.convert(location)).getType());
 	}
 
+	@Deprecated
 	public int getBlockTypeIdAt(int x, int y, int z)
 	{
 		return LegacyMaterial.getIdOf(world.getBlockAt(x, y, z).getType());

--- a/src/no/runsafe/framework/internal/wrapper/block/BukkitBlock.java
+++ b/src/no/runsafe/framework/internal/wrapper/block/BukkitBlock.java
@@ -39,11 +39,13 @@ public class BukkitBlock extends BukkitMetadata
 		setData(type.getData());
 	}
 
+	@Deprecated
 	public int getTypeId()
 	{
 		return LegacyMaterial.getIdOf(block.getType());
 	}
 
+	@Deprecated
 	public void setTypeId(int materialID)
 	{
 		block.setType(LegacyMaterial.getById(materialID));

--- a/src/no/runsafe/framework/internal/wrapper/block/BukkitBlockState.java
+++ b/src/no/runsafe/framework/internal/wrapper/block/BukkitBlockState.java
@@ -53,6 +53,7 @@ public class BukkitBlockState extends RunsafeBlock
 		setData(material.getData());
 	}
 
+	@Deprecated
 	public int getMaterialID()
 	{
 		return LegacyMaterial.getIdOf(blockState.getType());

--- a/src/no/runsafe/framework/internal/wrapper/entity/BukkitFallingBlock.java
+++ b/src/no/runsafe/framework/internal/wrapper/entity/BukkitFallingBlock.java
@@ -17,6 +17,7 @@ public abstract class BukkitFallingBlock extends RunsafeEntity
 		return block.getBlockData();
 	}
 
+	@Deprecated
 	public int getBlockId()
 	{
 		return LegacyMaterial.getIdOf(block.getMaterial());

--- a/src/no/runsafe/framework/internal/wrapper/entity/BukkitLivingEntity.java
+++ b/src/no/runsafe/framework/internal/wrapper/entity/BukkitLivingEntity.java
@@ -82,19 +82,37 @@ public abstract class BukkitLivingEntity extends RunsafeEntity implements ILivin
 	}
 
 	@Override
-	public List<IBlock> getLineOfSight(HashSet<Material> transparent, int maxDistance)
+	public List<IBlock> getBlocksInLineOfSight(HashSet<Material> transparent, int maxDistance)
 	{
 		return ObjectWrapper.convert(livingEntity.getLineOfSight(transparent, maxDistance));
 	}
 
 	@Override
-	public IBlock getTargetBlock(HashSet<Material> transparent, int maxDistance)
+	public IBlock getTargetedBlock(HashSet<Material> transparent, int maxDistance)
 	{
 		return ObjectWrapper.convert(livingEntity.getTargetBlock(transparent, maxDistance));
 	}
 
 	@Override
-	public List<IBlock> getLastTwoTargetBlocks(HashSet<Material> transparent, int maxDistance)
+	public List<IBlock> getLastTwoTargetedBlocks(HashSet<Material> transparent, int maxDistance)
+	{
+		return ObjectWrapper.convert(livingEntity.getLastTwoTargetBlocks(transparent, maxDistance));
+	}
+
+	@Override
+	public List<IBlock> getLineOfSight(HashSet<Byte> transparent, int maxDistance)
+	{
+		return ObjectWrapper.convert(livingEntity.getLineOfSight(transparent, maxDistance));
+	}
+	@Deprecated
+	@Override
+	public IBlock getTargetBlock(HashSet<Byte> transparent, int maxDistance)
+	{
+		return ObjectWrapper.convert(livingEntity.getTargetBlock(transparent, maxDistance));
+	}
+	@Deprecated
+	@Override
+	public List<IBlock> getLastTwoTargetBlocks(HashSet<Byte> transparent, int maxDistance)
 	{
 		return ObjectWrapper.convert(livingEntity.getLastTwoTargetBlocks(transparent, maxDistance));
 	}

--- a/src/no/runsafe/framework/internal/wrapper/entity/BukkitLivingEntity.java
+++ b/src/no/runsafe/framework/internal/wrapper/entity/BukkitLivingEntity.java
@@ -16,6 +16,7 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.util.Vector;
+import org.bukkit.Material;
 
 import javax.annotation.Nullable;
 import java.util.HashSet;
@@ -81,19 +82,19 @@ public abstract class BukkitLivingEntity extends RunsafeEntity implements ILivin
 	}
 
 	@Override
-	public List<IBlock> getLineOfSight(HashSet<Byte> transparent, int maxDistance)
+	public List<IBlock> getLineOfSight(HashSet<Material> transparent, int maxDistance)
 	{
 		return ObjectWrapper.convert(livingEntity.getLineOfSight(transparent, maxDistance));
 	}
 
 	@Override
-	public IBlock getTargetBlock(HashSet<Byte> transparent, int maxDistance)
+	public IBlock getTargetBlock(HashSet<Material> transparent, int maxDistance)
 	{
 		return ObjectWrapper.convert(livingEntity.getTargetBlock(transparent, maxDistance));
 	}
 
 	@Override
-	public List<IBlock> getLastTwoTargetBlocks(HashSet<Byte> transparent, int maxDistance)
+	public List<IBlock> getLastTwoTargetBlocks(HashSet<Material> transparent, int maxDistance)
 	{
 		return ObjectWrapper.convert(livingEntity.getLastTwoTargetBlocks(transparent, maxDistance));
 	}

--- a/src/no/runsafe/framework/internal/wrapper/item/BukkitItemStack.java
+++ b/src/no/runsafe/framework/internal/wrapper/item/BukkitItemStack.java
@@ -30,11 +30,13 @@ public abstract class BukkitItemStack implements ConfigurationSerializable, IWra
 		itemStack.setType(type);
 	}
 
+	@Deprecated
 	public int getItemId()
 	{
 		return LegacyMaterial.getIdOf(itemStack.getType());
 	}
 
+	@Deprecated
 	public void setItemId(int type)
 	{
 		itemStack.setType(LegacyMaterial.getById(type));

--- a/src/no/runsafe/framework/minecraft/RunsafeConsole.java
+++ b/src/no/runsafe/framework/minecraft/RunsafeConsole.java
@@ -25,12 +25,12 @@ public class RunsafeConsole implements ICommandExecutor
 
 	/**
 	* Gets the unique ID.
-	* @return null. The console doesn't have a unique ID.
+	* @return Zeroed out UUID.
 	*/
 	@Override
 	public UUID getUniqueId()
 	{
-		return null;
+		return consoleUUID;
 	}
 
 	@Override
@@ -84,6 +84,7 @@ public class RunsafeConsole implements ICommandExecutor
 		return name.hashCode();
 	}
 
+	private final UUID consoleUUID = UUID.fromString("00000000-0000-0000-0000-000000000000");
 	private final IConsole output;
 	private final String name;
 }

--- a/src/no/runsafe/framework/minecraft/entity/RunsafeLivingEntity.java
+++ b/src/no/runsafe/framework/minecraft/entity/RunsafeLivingEntity.java
@@ -42,7 +42,7 @@ public class RunsafeLivingEntity extends BukkitLivingEntity
 			if (material.isTransparent())
 				transparent.add(material);
 
-		return getTargetBlock(transparent, MAX_DISTANCE);
+		return getTargetedBlock(transparent, MAX_DISTANCE);
 	}
 
 	public RunsafeEntity Fire(String projectileType)

--- a/src/no/runsafe/framework/minecraft/entity/RunsafeLivingEntity.java
+++ b/src/no/runsafe/framework/minecraft/entity/RunsafeLivingEntity.java
@@ -37,10 +37,10 @@ public class RunsafeLivingEntity extends BukkitLivingEntity
 	@Override
 	public IBlock getTargetBlock()
 	{
-		HashSet<Byte> transparent = new HashSet<Byte>(10);
+		HashSet<Material> transparent = new HashSet<>(10);
 		for (Material material : Material.values())
 			if (material.isTransparent())
-				transparent.add((byte) (int) LegacyMaterial.getIdOf(material));
+				transparent.add(material);
 
 		return getTargetBlock(transparent, MAX_DISTANCE);
 	}


### PR DESCRIPTION
Three functions are changed instead of deprecating the old one and adding new ones because of HashSet clashing. This change is required for the later 1.12+ update.

Usage of block IDs are deprecated to make it easier to point them out in other plugins so they can be changed to prepare for 1.13+.

Console is given a UUID.