### PR TITLE
Remove dergon's ability to crash the server when their prey tries to run away from them

### DIFF
--- a/src/no/runsafe/framework/minecraft/Sound.java
+++ b/src/no/runsafe/framework/minecraft/Sound.java
@@ -190,6 +190,11 @@ public class Sound
 		public static final Sound Flute = new Sound(org.bukkit.Sound.BLOCK_NOTE_FLUTE);
 		public static final Sound Guitar = new Sound(org.bukkit.Sound.BLOCK_NOTE_GUITAR);
 		public static final Sound Xylophone = new Sound(org.bukkit.Sound.BLOCK_NOTE_XYLOPHONE);
+		public static final Sound Banjo = new Sound(org.bukkit.Sound.BLOCK_NOTE_GUITAR); // Placeholder
+		public static final Sound CowBell = new Sound(org.bukkit.Sound.BLOCK_NOTE_BELL); // Placeholder
+		public static final Sound Didgeridoo = new Sound(org.bukkit.Sound.BLOCK_NOTE_GUITAR); // Placeholder
+		public static final Sound Bit = new Sound(org.bukkit.Sound.BLOCK_NOTE_GUITAR); // Placeholder
+		public static final Sound IronXylophone = new Sound(org.bukkit.Sound.BLOCK_NOTE_XYLOPHONE); // Placeholder
 
 		private Note()
 		{

--- a/src/no/runsafe/framework/minecraft/bossBar/RunsafeBossBar.java
+++ b/src/no/runsafe/framework/minecraft/bossBar/RunsafeBossBar.java
@@ -28,10 +28,7 @@ public class RunsafeBossBar extends BukkitBossBar implements IBossBar
         // Remove players not on the new list
         for (IPlayer bossBarPlayer : bossBarPlayers)
             if (!players.contains(bossBarPlayer))
-            {
                 this.removePlayer(bossBarPlayer);
-                bossBarPlayers.remove(bossBarPlayer);
-            }
 
         // Add players not on the old list
         for (IPlayer newPlayer : players)


### PR DESCRIPTION
modifying a list while iterating through it can cause an exception, change setting boss bar players to not do that